### PR TITLE
iREVEAL build with dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jar
 *.zip
 .DS_Store
+\bin

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,11 @@
+Copyright <YEAR> <COPYRIGHT HOLDER>
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,30 @@ Automate tool to create reduced order model and export solution for CFD models
 * A practice of rebasing with the main repo should be used rather that merge commmits.
 
 ## Getting Started
+This software has been compiled and tested on Windows 7 professional
 
-TBD
+### Pre-requisites
+Your environment must have the following tools installed.
+The build has be tested with the following versions. Use other
+versions at your own risk.
+
++ Ant 1.9.6
++ Git Bash for windows
++ Java 1.8
++ 7z
+
+### Build and Package
+After installing the tools above run the Git Bash program.
+Executing the commands below tocompile the source and 
+and package the output
+
+
+```
+git clone https://github.com/CCSI-Toolset/iREVEAL.git
+cd iREVEAL
+start make.bat
+
+```
 
 ## Authors
 

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,26 @@
+REM iREVEAL make.bat
+
+REM
+
+REM This file is a reproductions of the iREVEAL 
+REM Jenkins build at LBNL. It has been tested on
+
+REM    - 64 bit windows 7 installation (required)
+
+REM
+
+REM Pre-requisites:
+
+REM    - Ant 1.9.6
+
+
+
+if NOT EXIST iREVEAL\lib. (
+  MKDIR iREVEAL\lib 
+)
+
+if NOT EXIST iREVEAL\lib\gson-2.2.4.jar. (
+  curl http://central.maven.org/maven2/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar -o iREVEAL\lib\gson-2.2.4.jar 
+)
+
+ant -f iREVEAL\build.xml && cd iREVEAL && 7z.exe a iREVEAL.zip iREVEAL.jar config ../docs/*iR*.pdf && cd ..


### PR DESCRIPTION
Closes #1
Closes #2

Added make.bat that pulls in gson library dependency, compiles the
 java and packages the release into a zip file.