### PR TITLE
Revised README.md for git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See installation manual in the [documentation](docs) subdirectory.
 
 
 ```
-git clone https://github.com/CCSI-Toolset/iREVEAL.git
+git clone https://github.com/CCSI-Toolset/iRevealLite.git
 ```
 
 ## Authors


### PR DESCRIPTION
fixed the master URL from CCSI-Toolset/iREVEAL to CCSI-Toolset/iRevealLite